### PR TITLE
Fix CI build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.16-alpine
+FROM golang:1.16
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ build: FORCE  ## build app
 
 
 test: ## Run unit tests
-     go test -failfast -covermode=count -coverprofile ${COVERAGE_FILE} ./...
-     @go tool cover -func=${COVERAGE_FILE} | grep 'total' | sed -e 's/\t\+/ /g'
-     @echo ✓ [make test-unit] Done
+	go test -failfast -covermode=count -coverprofile ${COVERAGE_FILE} ./...
+	@go tool cover -func=${COVERAGE_FILE} | grep 'total' | sed -e 's/\t\+/ /g'
+	@echo ✓ [make test-unit] Done
 
 install-dev: install tooling  ## install for dev environments
 


### PR DESCRIPTION
- Remove `-alpine` from Dockerfile base image, use vanilla `golang:1.16` instead
  - Reason being, Alpine makes you jump through compiler flags to run `go test`
- Fix leading whitespace in Makefile being spaces instead of just tab