### PR TITLE
Use compound notation for tag ratings constraint

### DIFF
--- a/app/cogs/cardboard/queryposts.go
+++ b/app/cogs/cardboard/queryposts.go
@@ -8,10 +8,14 @@ const (
 	unsafe    Safety = 2
 )
 
-var (
-	safeTags   = []string{"rating:g"}
-	unsafeTags = []string{"-rating:g", "-rating:s"}
+const (
+	safeTag   = "rating:g,s"
+	unsafeTag = "-rating:g,s"
 )
+
+func invertTagString(s string) string {
+	return "-" + s
+}
 
 // queryPosts implements IQueryPosts
 type queryPosts struct {
@@ -36,9 +40,9 @@ func (q *queryPosts) Tags() []string {
 	if q.MagicMode() {
 		switch q.safety {
 		case safe:
-			tags = append(tags, safeTags...)
+			tags = append(tags, safeTag)
 		case unsafe:
-			tags = append(tags, unsafeTags...)
+			tags = append(tags, unsafeTag)
 		}
 	}
 	return tags

--- a/app/cogs/cardboard/queryposts_test.go
+++ b/app/cogs/cardboard/queryposts_test.go
@@ -10,13 +10,12 @@ func Test_Tags_WithMagic_ShouldYieldRatingTags(t *testing.T) {
 	q := NewQuery("xyz").WithMagic()
 
 	q.WithSafe()
-	tags := []string{"xyz"}
 	actual := q.Tags()
-	assert.Equal(t, append(tags, safeTags...), actual)
+	assert.Equal(t, []string{"xyz", "rating:g,s"}, actual)
 
 	q.WithUnsafe()
 	actual = q.Tags()
-	assert.Equal(t, append(tags, unsafeTags...), actual)
+	assert.Equal(t, []string{"xyz", "-rating:g,s"}, actual)
 }
 
 func Test_Tags_WithNoMagic_ShouldDropRatingTags(t *testing.T) {
@@ -25,12 +24,12 @@ func Test_Tags_WithNoMagic_ShouldDropRatingTags(t *testing.T) {
 	q.WithSafe()
 	actual := q.Tags()
 	assert.Contains(t, actual, "xyz")
-	assert.NotContains(t, actual, unsafeTags)
-	assert.NotContains(t, actual, safeTags)
+	assert.NotContains(t, actual, unsafeTag)
+	assert.NotContains(t, actual, safeTag)
 
 	q.WithUnsafe()
 	actual = q.Tags()
 	assert.Contains(t, actual, "xyz")
-	assert.NotContains(t, actual, unsafeTags)
-	assert.NotContains(t, actual, safeTags)
+	assert.NotContains(t, actual, unsafeTag)
+	assert.NotContains(t, actual, safeTag)
 }


### PR DESCRIPTION
Use `rating:g,s` to constraint/exclude `g` and `s` ratings. This approximately mimics the original semantics of `rating:s` prior to the introduction of `g`.