### PR TITLE
Fix rolePattern regexp to account for #0 denom

### DIFF
--- a/app/cogs/colours/domain.go
+++ b/app/cogs/colours/domain.go
@@ -19,7 +19,7 @@ var (
 	ErrRerollCooldownPending = errors.New("reroll cooldown is still in progress")
 	ErrInvalidRoleHeight     = errors.New("invalid target role height, it should be >=0")
 
-	rolePattern = regexp.MustCompile(`\w+#\d{4}`)
+	rolePattern = regexp.MustCompile(`\w+#(0|\d{4})`)
 )
 
 type domain struct {

--- a/app/cogs/colours/domain_test.go
+++ b/app/cogs/colours/domain_test.go
@@ -80,6 +80,11 @@ func Test_GetColourRole(t *testing.T) {
 			currentRoleName: "abcd#1234",
 			expectFound:     true,
 		},
+		{
+			desc:            "have roles, role name has new #0 denominator",
+			currentRoleName: "abcd#0",
+			expectFound:     true,
+		},
 	}
 	for _, tc := range testCases {
 		ctrl := gomock.NewController(t)


### PR DESCRIPTION
Ever since Discord migrated away from numerically-denominated usernames in the form of `username#1234`, usernames now have a provisional denominator of `#0`.