### PR TITLE
Workaround for duplicated interationCreate handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20'
+        go-version: '1.22'
 
     - name: Build
       run: make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.20
+FROM golang:1.22
 
 WORKDIR /app
 

--- a/app/cogs/colours/cmd_colinfo_test.go
+++ b/app/cogs/colours/cmd_colinfo_test.go
@@ -1,6 +1,7 @@
 package colours
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -171,6 +172,7 @@ func Test_formatColInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			reply, err := cog.formatColInfo(
+				context.Background(),
 				now,
 				tc.rerollCDEndTime,
 				tc.lastMutateTime,
@@ -211,6 +213,7 @@ func Test_horizontalPartitionImage(t *testing.T) {
 }
 
 func Test_makeColHistoryImg(t *testing.T) {
+	ctx := context.Background()
 	h := &History{
 		start: unix(00),
 		end:   unix(40),
@@ -220,7 +223,7 @@ func Test_makeColHistoryImg(t *testing.T) {
 		},
 	}
 
-	file, fileExt, fileContent, err := makeColHistoryImg(h, 20*time.Second)
+	file, fileExt, fileContent, err := makeColHistoryImg(ctx, h, 20*time.Second)
 	assert.NoError(t, err)
 	assert.NotNil(t, file)
 	assert.Equal(t, "png", fileExt)

--- a/app/engine/eventsregistry.go
+++ b/app/engine/eventsregistry.go
@@ -13,7 +13,7 @@ import (
 
 func NewEventHandler[E types.SupportedEvents](callable func(context.Context, *dgo.Session, E)) func(*dgo.Session, E) {
 	return func(s *dgo.Session, evt E) {
-		traceID := fmt.Sprintf("%T-%d", evt, time.Now().UTC().Unix())
+		traceID := fmt.Sprintf("%T-%d", evt, time.Now().UTC().UnixMilli())
 		ctx := context.Background()
 		ctx = log.Put(ctx, log.TraceID, traceID)
 

--- a/app/engine/handler_idempotency.go
+++ b/app/engine/handler_idempotency.go
@@ -1,0 +1,70 @@
+package engine
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/btree"
+)
+
+// Requests that share an idempotencyKey with another request within this time window
+// will be considered duplicates which should be ignored.
+const idempotencyWindow = 2 * time.Minute
+
+type idempotencyKey struct {
+	key        string
+	acquiredAt time.Time
+}
+
+func (ik *idempotencyKey) Before(other *idempotencyKey) bool {
+	return ik.acquiredAt.Before(other.acquiredAt)
+}
+
+type handlerIdempotency struct {
+	tree  *btree.BTreeG[*idempotencyKey]
+	mutex *sync.Mutex
+	clock func() time.Time
+}
+
+func newHandlerIdempotency() *handlerIdempotency {
+	var mu sync.Mutex
+	var degree int = 2 // idk wtf this means, looks like higher = lower memory usage but slower inserts?
+	return &handlerIdempotency{
+		tree:  btree.NewG(degree, func(a, b *idempotencyKey) bool { return a.Before(b) }),
+		mutex: &mu,
+		clock: time.Now,
+	}
+}
+
+// Acquire attempts to acquire a lock against the given key.
+// If there is no existing lock, it creates the lock using the given key and retuns true.
+// Otherwise, it returns false.
+func (hi *handlerIdempotency) Acquire(key string) (acquired bool) {
+	hi.mutex.Lock()
+	defer hi.mutex.Unlock()
+
+	now := hi.clock()
+	acquired = true
+
+	hi.tree.Ascend(func(item *idempotencyKey) bool {
+		age := now.Sub(item.acquiredAt)
+		if age > idempotencyWindow {
+			hi.tree.Delete(item)
+			return true // continue iterating tree
+		}
+
+		if item.key == key {
+			acquired = false
+			return false
+		}
+		return true
+	})
+
+	if acquired {
+		hi.tree.ReplaceOrInsert(&idempotencyKey{
+			key:        key,
+			acquiredAt: now,
+		})
+	}
+	return
+}

--- a/app/engine/handler_idempotency_test.go
+++ b/app/engine/handler_idempotency_test.go
@@ -1,0 +1,44 @@
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fiffu/arisa3/lib"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_idempotencyKey_Before(t *testing.T) {
+	now := time.Now().UTC()
+	x := &idempotencyKey{"", now}
+	xx := &idempotencyKey{"", now}
+	y := &idempotencyKey{"", now.Add(1)}
+
+	assert.True(t, x.Before(y))
+	assert.False(t, y.Before(x))
+	assert.False(t, y.Before(xx))
+}
+
+func Test_handlerIdempotency_Acquire(t *testing.T) {
+	hi := newHandlerIdempotency()
+	assert.True(t, hi.Acquire("abc"))
+	assert.True(t, hi.Acquire("def"))
+	assert.False(t, hi.Acquire("abc"))
+}
+
+func Test_handlerIdempotency_Acquire_afterExpiry(t *testing.T) {
+	hi := newHandlerIdempotency()
+	clock := lib.FrozenNow(t)
+	hi.clock = clock.Now
+
+	assert.True(t, hi.Acquire("abc"))
+	assert.Equal(t, 1, hi.tree.Len())
+
+	clock.Add(1 + 2*idempotencyWindow) // time passes
+	assert.True(t, hi.Acquire("def"))
+	assert.Equal(t, 1, hi.tree.Len()) // key 'abc' should have been deleted
+
+	clock.Add(1)                      // later...
+	assert.True(t, hi.Acquire("abc")) // since 'abc' was deleted, we can acquire it again
+	assert.Equal(t, 2, hi.tree.Len()) // now there should be 2 keys
+}

--- a/app/log/log.go
+++ b/app/log/log.go
@@ -134,7 +134,7 @@ func newEntry(ctx context.Context, entry *zero.Event, caller, msg string) (strin
 
 func SetupLogger() {
 	output := zero.ConsoleWriter{Out: os.Stdout}
-	output.TimeFormat = "2006/01/02 15:04:05"
+	output.TimeFormat = "2006/01/02 15:04:05.00000"
 	output.FormatMessage = func(i interface{}) string {
 		return fmt.Sprintf(":: %s  ", i)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/fiffu/arisa3
 
-go 1.20
+go 1.21.3
+
+toolchain go1.22.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
@@ -9,6 +11,7 @@ require (
 	github.com/carlmjohnson/requests v0.22.3
 	github.com/go-playground/validator/v10 v10.10.1
 	github.com/golang/mock v1.6.0
+	github.com/google/btree v1.1.3
 	github.com/honeycombio/honeycomb-opentelemetry-go v0.8.1
 	github.com/honeycombio/otel-config-go v1.12.1
 	github.com/lib/pq v1.10.5

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,7 @@ github.com/go-playground/validator/v10 v10.10.1/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
+github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -123,6 +124,8 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
+github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -176,6 +179,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -212,6 +216,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.29.1 h1:cO+d60CHkknCbvzEWxP0S9K6KqyTjrCNUy1LdQLCGPc=
 github.com/rs/zerolog v1.29.1/go.mod h1:Le6ESbR7hc+DP6Lt1THiV8CQSdkkNrd3R0XbEgp3ZBU=
@@ -266,6 +271,7 @@ go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 go.opentelemetry.io/contrib/detectors/aws/lambda v0.44.0 h1:s+4DQOUrFZwKOS2cOQf9RwVgg0ZtUSSsi17PdDOz96g=
+go.opentelemetry.io/contrib/detectors/aws/lambda v0.44.0/go.mod h1:DtJoiPxV7q/w2hqGPZSOfjfIigK/tkgihpsQhQFDl/Q=
 go.opentelemetry.io/contrib/instrumentation/host v0.44.0 h1:SNqDjPpQmwFYvDipyJJxDbU5zKNWiYSMii864ubzIuQ=
 go.opentelemetry.io/contrib/instrumentation/host v0.44.0/go.mod h1:bZcqg3yy0riQLNkx8dJWV4J3tbfL+6LQ5lIbI+vmarE=
 go.opentelemetry.io/contrib/instrumentation/runtime v0.44.0 h1:TXu20nL4yYfJlQeqG/D3Ia6b0p2HZmLfJto9hqJTQ/c=
@@ -301,6 +307,7 @@ go.opentelemetry.io/otel/trace v1.18.0/go.mod h1:T2+SGJGuYZY3bjj5rgh/hN7KIrlpWC5
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -590,6 +597,7 @@ google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210108203827-ffc7fda8c3d7/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20230711160842-782d3b101e98 h1:Z0hjGZePRE0ZBWotvtrwxFNrNE9CUAGtplaDK5NNI/g=
+google.golang.org/genproto v0.0.0-20230711160842-782d3b101e98/go.mod h1:S7mY02OqCJTD0E1OiQy1F72PWFB4bZJ87cAtLPYgDR0=
 google.golang.org/genproto/googleapis/api v0.0.0-20230711160842-782d3b101e98 h1:FmF5cCW94Ij59cfpoLiwTgodWmm60eEV0CjlsVg2fuw=
 google.golang.org/genproto/googleapis/api v0.0.0-20230711160842-782d3b101e98/go.mod h1:rsr7RhLuwsDKL7RmgDDCUc6yaGr1iqceVb5Wv6f6YvQ=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 h1:bVf09lpb+OJbByTj913DRJioFFAjf/ZGxEz7MajTp2U=

--- a/lib/clock.go
+++ b/lib/clock.go
@@ -1,0 +1,30 @@
+package lib
+
+import (
+	"testing"
+	"time"
+)
+
+type frozenClock struct {
+	timestamp time.Time
+}
+
+func (fc *frozenClock) Now() time.Time {
+	return fc.timestamp
+}
+
+func (fc *frozenClock) Add(duration time.Duration) {
+	fc.timestamp = fc.timestamp.Add(duration)
+}
+
+func (fc *frozenClock) Set(timestamp time.Time) {
+	fc.timestamp = timestamp
+}
+
+func FrozenClock(t *testing.T, timestamp time.Time) *frozenClock {
+	return &frozenClock{timestamp}
+}
+
+func FrozenNow(t *testing.T) *frozenClock {
+	return FrozenClock(t, time.Now())
+}

--- a/lib/clock_test.go
+++ b/lib/clock_test.go
@@ -1,0 +1,27 @@
+package lib
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_FrozenClock(t *testing.T) {
+	now := time.Now()
+	fc := FrozenClock(t, now)
+
+	assert.Equal(t, now, fc.Now())
+
+	positive := 5 * time.Minute
+	fc.Add(positive)
+	assert.Equal(t, now.Add(positive), fc.Now())
+
+	negative := -2 * time.Second
+	fc.Add(negative)
+	assert.Equal(t, now.Add(positive).Add(negative), fc.Now())
+
+	now2 := time.Now().Add(30 * time.Millisecond)
+	fc.Set(now2)
+	assert.Equal(t, now2, fc.Now())
+}


### PR DESCRIPTION
## background

For some reason, we typically see duplicated calls to our `onInteractionCreate` command handler for slash commands.

I don't know why this happens, but it's mainly visible on `/roll` since it has a cooldown associated. There's a race condition such that
- the intial handler fires first without issue -- the cooldown check passes and a new colour is assigned, the Discord APi call goes up and changes are committed on the DB
- the duplicated handler call fires -- now the cooldown check fails, we immediately respond to the interaction

Since the duplicate handler does substantially less work, it returns much earlier to the interaction. The user sees that message about the cooldown. The initial handler sees a HTTP400 when trying to respond with a success message.

## fix

- Introduce a workaround by adding an idempotency check with an in-memory mutex
- Increase time resolution in parts of the log which are time-based to improve tracing

This is more of a workaround since I don't know what's actually causing the duplicate handler. We might have to check the commandRegistry code for clues, although I don't think it's doing anything weird